### PR TITLE
Add SSE demo with Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # sse-streaming-demo
-SSE（Server-Sent Events）のストリーミングデモ用リポジトリ
+
+SinatraとNginxでSSEとチャンク配信を試すデモ。Docker Composeひとつで起動できます。
+
+## 起動
+
+```bash
+docker compose up --build
+```
+
+ブラウザで <http://localhost:8080> を開くと、SSEやReadableStreamのデモページが表示されます。
+
+停止するには別ターミナルで以下を実行します。
+
+```bash
+docker compose down
+```

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,17 @@
+FROM ruby:3.4.4-alpine
+
+RUN apk add --no-cache build-base curl
+
+WORKDIR /app
+
+COPY Gemfile* ./
+RUN bundle config set deployment 'true' \
+ && bundle config set without 'development test' \
+ && bundle install
+
+COPY . .
+
+ENV RACK_ENV=production
+EXPOSE 9292
+
+CMD ["ruby", "app.rb"]

--- a/app/Gemfile
+++ b/app/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "sinatra", "~> 3.0"
+gem "puma", "~> 6.0"

--- a/app/app.rb
+++ b/app/app.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+require "sinatra"
+require "sinatra/streaming"
+require "json"
+
+set :server, :puma
+set :bind, "0.0.0.0"
+set :port, 9292
+
+helpers Sinatra::Streaming
+
+get "/" do
+  send_file File.join(settings.public_folder, "index.html")
+end
+
+# SSE（ChatGPT風ストリーミング）
+get "/sse" do
+  content_type "text/event-stream"
+  headers["Cache-Control"]     = "no-cache"
+  headers["Connection"]        = "keep-alive"
+  headers["X-Accel-Buffering"] = "no"
+
+  prompt = params["prompt"].to_s
+  tokens = (prompt.empty? ? "これはSSEのデモです。" : "「#{prompt}」への応答をストリーミング中。").chars
+
+  stream(:keep_open) do |out|
+    out << "retry: 2000\n\n"
+
+    Thread.new do
+      begin
+        tokens.each_with_index do |ch, i|
+          out << "event: token\n"
+          out << "data: #{({ index: i, text: ch }.to_json)}\n\n"
+          sleep 0.05
+        end
+        out << "event: done\n"
+        out << "data: [DONE]\n\n"
+      rescue => e
+        out << "event: error\n"
+        out << "data: #{({ error: e.class.name, message: e.message }.to_json)}\n\n"
+      ensure
+        out.close
+      end
+    end
+  end
+end
+
+# おまけ：SSEではない素のchunk配信
+get "/chunk" do
+  content_type "text/plain; charset=utf-8"
+  headers["Cache-Control"]     = "no-cache"
+  headers["X-Accel-Buffering"] = "no"
+
+  stream do |out|
+    "これはchunked transferのデモです。\n".chars.each do |ch|
+      out << ch
+      sleep 0.05
+    end
+  end
+end

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="ja">
+  <meta charset="utf-8" />
+  <title>SSE Streaming Demo</title>
+  <style>
+    body { font-family: system-ui, sans-serif; padding: 2rem; line-height: 1.6; }
+    .row { display: flex; gap: 1rem; align-items: center; }
+    #out, #out2 { white-space: pre-wrap; border: 1px solid #ddd; padding: 1rem; border-radius: 8px; min-height: 4rem; }
+    input[type="text"] { width: 24rem; padding: .5rem; }
+    button { padding: .5rem 1rem; cursor: pointer; }
+    h2 { margin-top: 2rem; }
+  </style>
+
+  <h1>ChatGPT風ストリーミング（SSE / chunk）</h1>
+
+  <div class="row">
+    <input id="prompt" type="text" placeholder="プロンプト（任意）">
+    <button id="start">SSE開始</button>
+    <button id="stop">SSE停止</button>
+  </div>
+  <div id="out"></div>
+
+  <h2>おまけ：fetch + ReadableStream（chunked）</h2>
+  <div class="row">
+    <button id="start2">/chunk にfetch</button>
+    <button id="stop2">停止</button>
+  </div>
+  <div id="out2"></div>
+
+  <script>
+    // ===== SSE版（EventSource） =====
+    const out = document.getElementById("out");
+    const promptInput = document.getElementById("prompt");
+    let es = null;
+
+    function startSSE() {
+      if (es) es.close();
+      out.textContent = "";
+
+      const u = new URL("/sse", window.location.origin);
+      if (promptInput.value) u.searchParams.set("prompt", promptInput.value);
+
+      es = new EventSource(u);
+      es.addEventListener("token", (e) => {
+        try { out.textContent += JSON.parse(e.data).text; }
+        catch { out.textContent += e.data; }
+      });
+      es.addEventListener("done", () => es.close());
+      es.addEventListener("error", (e) => { console.error("SSE error", e); es.close(); });
+    }
+
+    document.getElementById("start").onclick = startSSE;
+    document.getElementById("stop").onclick  = () => es && es.close();
+
+    // ===== fetch + ReadableStream版（chunked） =====
+    const out2 = document.getElementById("out2");
+    let readerAbort = null;
+
+    async function startChunk() {
+      out2.textContent = "";
+      readerAbort && readerAbort.abort();
+      readerAbort = new AbortController();
+
+      const res = await fetch("/chunk", { signal: readerAbort.signal });
+      if (!res.body) { out2.textContent = "ReadableStream未対応かも…"; return; }
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          out2.textContent += decoder.decode(value, { stream: true });
+        }
+      } catch (e) {
+        if (e.name !== "AbortError") console.error(e);
+      }
+    }
+
+    document.getElementById("start2").onclick = startChunk;
+    document.getElementById("stop2").onclick  = () => readerAbort && readerAbort.abort();
+  </script>
+</html>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.9"
+services:
+  app:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+    expose:
+      - "9292"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9292/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+  nginx:
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    depends_on:
+      app:
+        condition: service_healthy
+    restart: unless-stopped

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.27-alpine
+COPY nginx.conf /etc/nginx/nginx.conf
+EXPOSE 8080

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,54 @@
+worker_processes auto;
+events { worker_connections 1024; }
+
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+  keepalive_timeout 65;
+
+  upstream sinatra_upstream {
+    server app:9292;
+    keepalive 10;
+  }
+
+  server {
+    listen 8080;
+    server_name _;
+
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    location / {
+      proxy_pass http://sinatra_upstream;
+    }
+
+    location /sse {
+      proxy_pass http://sinatra_upstream;
+      proxy_buffering off;
+      proxy_cache off;
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
+      add_header X-Accel-Buffering no;
+      proxy_read_timeout 3600s;
+      proxy_send_timeout 3600s;
+      gzip off;
+    }
+
+    location /chunk {
+      proxy_pass http://sinatra_upstream;
+      proxy_buffering off;
+      proxy_cache off;
+      proxy_http_version 1.1;
+      proxy_read_timeout 3600s;
+      proxy_send_timeout 3600s;
+      gzip off;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Sinatra app (Ruby 3.4.4) streaming tokens via SSE
- Nginx reverse proxy with buffering disabled
- docker-compose for one-command startup

## Testing
- `ruby -c app/app.rb`
- `ruby -v`


------
https://chatgpt.com/codex/tasks/task_e_689b4e693670832082c9dab105de0141